### PR TITLE
Fix brace repetition qualifier {0,n}

### DIFF
--- a/crossword/regex_parser.py
+++ b/crossword/regex_parser.py
@@ -155,6 +155,8 @@ class RegexParser:
         times2 = int(p[5])
         cases = []
         for l in range(times1, times2+1):
+            if l == 0:
+                continue
             case = reduce(lambda x, y: (CONCAT, x, y), [inner for _ in range(l)])
             cases.append(case)
         p[0] = reduce(lambda x, y: (BAR, x, y), cases)

--- a/crossword/tests/test_parser.py
+++ b/crossword/tests/test_parser.py
@@ -106,6 +106,8 @@ class BraceTest(ParserTestCase):
                                            (CONCAT, (CHAR, 'A'), (CHAR, 'A'))),
                                      (CONCAT, (CONCAT, (CHAR, 'A'), (CHAR, 'A')),
                                               (CHAR, 'A'))))
+    def test_four(self):
+        self.do_test("A{0,1}", (CHAR, 'A'))
 
 class GroupTest(ParserTestCase):
     def test_simple(self):


### PR DESCRIPTION
Hi, 
This PR should fix the following error with the use of brace repetition qualifiers starting from 0:
`TypeError: reduce() of empty sequence with no initial value`

Test is added.