### PR TITLE
Fix quantifiers {0}, {0,}, {0,n}

### DIFF
--- a/crossword/regex_parser.py
+++ b/crossword/regex_parser.py
@@ -141,12 +141,18 @@ class RegexParser:
         """factor : factor LBRACE number RBRACE"""
         inner = p[1]
         times = int(p[3])
+        if times == 0:
+            p[0] = (EMPTY,)
+            return
         p[0] = reduce(lambda x, y: (CONCAT, x, y), [inner for _ in range(times)])
     def p_factor_brace_2(self, p):
         """factor : factor LBRACE number COMMA RBRACE"""
         inner = p[1]
         times = int(p[3])
-        prefix = reduce(lambda x, y: (CONCAT, x, y), [inner for _ in range(times)])
+        if times == 0:
+            prefix = (EMPTY,)
+        else:
+            prefix = reduce(lambda x, y: (CONCAT, x, y), [inner for _ in range(times)])
         p[0] = (CONCAT, prefix, (STAR, inner))
     def p_factor_brace_3(self, p):
         """factor : factor LBRACE number COMMA number RBRACE"""
@@ -156,6 +162,7 @@ class RegexParser:
         cases = []
         for l in range(times1, times2+1):
             if l == 0:
+                cases.append((EMPTY,))
                 continue
             case = reduce(lambda x, y: (CONCAT, x, y), [inner for _ in range(l)])
             cases.append(case)

--- a/crossword/tests/test_parser.py
+++ b/crossword/tests/test_parser.py
@@ -107,7 +107,7 @@ class BraceTest(ParserTestCase):
                                      (CONCAT, (CONCAT, (CHAR, 'A'), (CHAR, 'A')),
                                               (CHAR, 'A'))))
     def test_four(self):
-        self.do_test("A{0,1}", (CHAR, 'A'))
+        self.do_test("A{0,1}", (BAR, (EMPTY,), (CHAR, 'A')))
 
 class GroupTest(ParserTestCase):
     def test_simple(self):

--- a/crossword/tests/test_solver.py
+++ b/crossword/tests/test_solver.py
@@ -67,14 +67,21 @@ class QuantifierTest(SolverTestCase):
         self.do_test("a?", 1)
         self.do_test("a?", 2, False)
     def test_brace_one(self):
+        self.do_test("a{0}", 0)
+        self.do_test("a{0}", 1, False)
         self.do_test("a{2}", 1, False)
         self.do_test("a{2}", 2)
         self.do_test("a{2}", 3, False)
     def test_brace_two(self):
+        self.do_test("a{0,}", 0)
+        self.do_test("a{0,}", 1)
         self.do_test("a{2,}", 1, False)
         self.do_test("a{2,}", 2)
         self.do_test("a{2,}", 3)
     def test_brace_three(self):
+        self.do_test("a{0,2}", 0)
+        self.do_test("a{0,2}", 1)
+        self.do_test("a{0,2}", 2)
         self.do_test("a{2,4}", 1, False)
         self.do_test("a{2,4}", 2)
         self.do_test("a{2,4}", 3)


### PR DESCRIPTION
Hi, I discovered another test file and added more tests;
It appears that my previous fix was incomplete; sorry about that.

- Now the 3 types of brace quantifiers should be covered by tests
- The code is fixed as it should return EMPTY if quantifier is 0 in any situation